### PR TITLE
Added build with client-side routing and npm start script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /*.env
+/client/build

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const cors = require('cors');
 const express = require('express');
 const mongoose = require('mongoose');
 const morgan = require('morgan');
+const path = require('path');
 
 const options = {
     key: fs.readFileSync("rootSSL.key"),
@@ -30,15 +31,15 @@ app.use(express.json({ limit : '50mb' }));
 app.use(express.urlencoded({ extended : true, limit : '50mb' }));
 app.use(morgan("combined"));
 
-app.get('/api', (req, res) => {
-    res.sendFile("client/index.html");
-});
-
 app.use('/api/visitor', visitor);
 app.use('/api/faculty', faculty);
 app.use('/api/dashboard', visitingDetails);
 app.use('/api/admin', admin);
 app.use(express.static('client/build'));
+
+app.get('/*', (req, res) => {
+    res.sendFile(path.join(__dirname, "client/build/index.html"));
+});
 
 app.set('view engine', 'ejs');
 db.on('error', console.error.bind(console, 'MongoDB Connection Error:'));

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jshint models/ && jshint index.js",
     "client-install": "npm install --prefix client",
-    "start": "node index.js",
+    "client-build": "cd client && npm run build",
+    "start": "npm run client-build && node index.js",
     "server": "nodemon index.js",
     "client": "npm start --prefix client",
     "dev": "concurrently \" npm run server \" \" npm run client \""

--- a/routes/faculty.route.js
+++ b/routes/faculty.route.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../middleware/auth');
 const faculty_controller = require("../controllers/faculty.controller");
 
-router.get("/", faculty_controller.faculty_retrieve);
+router.get("/", auth, faculty_controller.faculty_retrieve);
 router.post("/create",auth, faculty_controller.faculty_create);
 
 module.exports = router;


### PR DESCRIPTION
Run `npm start` on root and open `https://localhost:5000` on browser.